### PR TITLE
chore: dconde-qs-python to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,6 +2,9 @@ dependencies:
 - name: dave-cjxd-ds-test
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: dconde-qs-python
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
chore: Promote dconde-qs-python to version 0.0.1